### PR TITLE
Eliminating bounds checks in the YUV->RGBA conversion

### DIFF
--- a/yuv/src/bt601.rs
+++ b/yuv/src/bt601.rs
@@ -164,9 +164,11 @@ fn convert_and_write_pixel(yuv: (u8, u8, u8), rgba: &mut Vec<u8>, base: usize, l
     let g = (y + luts.cr_to_g[r_sample as usize] + luts.cb_to_g[b_sample as usize] + 8) >> 4;
     let b = (y + luts.cb_to_b[b_sample as usize] + 8) >> 4;
 
-    rgba[base] = r.clamp(0, 255) as u8;
-    rgba[base + 1] = g.clamp(0, 255) as u8;
-    rgba[base + 2] = b.clamp(0, 255) as u8;
+    // the unsafes down here rely on the fact that base will not overflow rgba
+    debug_assert!(base + 4 <= rgba.len()); // the + 4 is for the alpha channel, even though we're not writing that here
+    *unsafe { rgba.get_unchecked_mut(base) } = r.clamp(0, 255) as u8;
+    *unsafe { rgba.get_unchecked_mut(base + 1) } = g.clamp(0, 255) as u8;
+    *unsafe { rgba.get_unchecked_mut(base + 2) } = b.clamp(0, 255) as u8;
 }
 
 /// Convert YUV 4:2:0 data into RGB 1:1:1 data.

--- a/yuv/src/bt601.rs
+++ b/yuv/src/bt601.rs
@@ -38,31 +38,31 @@ fn sample_chroma_for_luma(
             (luma_y as i32 - 1) / 2
         };
 
-        sample_00 = chroma
-            .get(clamped_index(width, height, chroma_x, chroma_y))
-            .copied()
-            .unwrap_or(0) as u16;
-        sample_10 = chroma
-            .get(clamped_index(width, height, chroma_x + 1, chroma_y))
-            .copied()
-            .unwrap_or(0) as u16;
-        sample_01 = chroma
-            .get(clamped_index(width, height, chroma_x, chroma_y + 1))
-            .copied()
-            .unwrap_or(0) as u16;
-        sample_11 = chroma
-            .get(clamped_index(width, height, chroma_x + 1, chroma_y + 1))
-            .copied()
-            .unwrap_or(0) as u16;
+        debug_assert!(clamped_index(width, height, chroma_x + 1, chroma_y + 1) < chroma.len());
+        unsafe {
+            sample_00 =
+                *chroma.get_unchecked(clamped_index(width, height, chroma_x, chroma_y)) as u16;
+            sample_10 =
+                *chroma.get_unchecked(clamped_index(width, height, chroma_x + 1, chroma_y)) as u16;
+            sample_01 =
+                *chroma.get_unchecked(clamped_index(width, height, chroma_x, chroma_y + 1)) as u16;
+            sample_11 =
+                *chroma.get_unchecked(clamped_index(width, height, chroma_x + 1, chroma_y + 1))
+                    as u16;
+        }
     } else {
         let chroma_x = (luma_x as i32 - 1) / 2;
         let chroma_y = (luma_y as i32 - 1) / 2;
 
         let base = unclamped_index(width, chroma_x, chroma_y);
-        sample_00 = chroma.get(base).copied().unwrap_or(0) as u16;
-        sample_10 = chroma.get(base + 1).copied().unwrap_or(0) as u16;
-        sample_01 = chroma.get(base + chroma_width).copied().unwrap_or(0) as u16;
-        sample_11 = chroma.get(base + chroma_width + 1).copied().unwrap_or(0) as u16;
+
+        debug_assert!(base + chroma_width + 1 < chroma.len());
+        unsafe {
+            sample_00 = *chroma.get_unchecked(base) as u16;
+            sample_10 = *chroma.get_unchecked(base + 1) as u16;
+            sample_01 = *chroma.get_unchecked(base + chroma_width) as u16;
+            sample_11 = *chroma.get_unchecked(base + chroma_width + 1) as u16;
+        }
     }
 
     let interp_left = luma_x % 2 != 0;


### PR DESCRIPTION
~These changes together yield an *overall* &Tilde;21% reduction of the time `run_frame()` takes, on average.~ (outdated)
Measured on the self-hosted web build, running the first 100 frames of z0r loops 3664, 4449, and 7081; but discarding the first 20 frame times of each loop before averaging - to let the WASM JIT warm up, and the numbers stabilize a little.

The results:
![image](https://user-images.githubusercontent.com/288816/131758300-41f8fdf1-a0aa-423f-8d94-9d19fbe99984.png)
The first and last rows are about the current state, the middle rows are some "milestone" commits of this PR. The X axis is milliseconds. Every measurement was done four times.
The benchmarks were done in Chromium 94, on a Ryzen 2700X (using `playwright` and the `temci` tool).

~The first two commits I'm fairly confident in being "good", the middle one is just "okay", and the last two "should be fine, I think".~ _(outdated)_

More details about the changes in the added comments.