### PR TITLE
Optimize the YUV->RGBA conversion with lookup tables

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,9 @@ dependencies = [
 [[package]]
 name = "h263-rs-yuv"
 version = "0.1.0"
+dependencies = [
+ "lazy_static",
+]
 
 [[package]]
 name = "lazy_static"

--- a/yuv/Cargo.toml
+++ b/yuv/Cargo.toml
@@ -4,3 +4,6 @@ version = "0.1.0"
 authors = ["Mike Welsh <mwelsh@gmail.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
+
+[dependencies]
+lazy_static = "1.4.0"

--- a/yuv/src/bt601.rs
+++ b/yuv/src/bt601.rs
@@ -3,7 +3,7 @@
 use lazy_static::lazy_static;
 
 fn clamped_index(width: i32, height: i32, x: i32, y: i32) -> usize {
-    (x.max(0).min(width - 1) + (y.max(0).min(height - 1) * width)) as usize
+    (x.clamp(0, width - 1) + (y.clamp(0, height - 1) * width)) as usize
 }
 
 fn unclamped_index(width: i32, x: i32, y: i32) -> usize {


### PR DESCRIPTION
This is the first, "safe" half of https://github.com/ruffle-rs/h263-rs/pull/6 extracted, with some minor changes for better readability.
This does not introduce any new unsoundness AFAIK, as it only optimizes the single-pixel-level conversion.

None of @kmeisthax's (rightful, BTW) concerns of that PR are about this part, if I'm not mistaken, and this already provides some measurable speedup.

So let's consider including just these changes first!