### PR TITLE
Speed up YUV->RGBA conversion by utilizing iterators, and processing 2x2 group of pixels at once

### DIFF
--- a/yuv/src/bt601.rs
+++ b/yuv/src/bt601.rs
@@ -533,6 +533,82 @@ fn test_yuv_to_rgb() {
     assert_eq!(yuv_to_rgb((126, 128, 128), &LUTS), (128, 128, 128));
 }
 
+// Inverse conversion, for testing purposes only
+#[cfg(test)]
+fn rgb_to_yuv(rgb: (u8, u8, u8)) -> (u8, u8, u8) {
+    let (red, green, blue) = rgb;
+    let (red, green, blue) = (red as f32, green as f32, blue as f32);
+
+    // From the same Wikipedia article as LUTs::new()
+    let y = 16.0 + (65.481 * red) / 255.0 + (128.553 * green) / 255.0 + (24.966 * blue) / 255.0;
+    let u = 128.0 - (37.797 * red) / 255.0 - (74.203 * green) / 255.0 + (112.0 * blue) / 255.0;
+    let v = 128.0 + (112.0 * red) / 255.0 - (93.786 * green) / 255.0 - (18.214 * blue) / 255.0;
+
+    (y.round() as u8, u.round() as u8, v.round() as u8)
+}
+
+// The function used for testing should also have its own tests :)
+#[test]
+fn test_rgb_to_yuv() {
+    // black is Y=16
+    assert_eq!(rgb_to_yuv((0, 0, 0)), (16, 128, 128));
+    assert_eq!(rgb_to_yuv((1, 1, 1)), (17, 128, 128));
+
+    // white is Y=235
+    assert_eq!(rgb_to_yuv((254, 254, 254)), (234, 128, 128));
+    assert_eq!(rgb_to_yuv((255, 255, 255)), (235, 128, 128));
+
+    assert_eq!(
+        rgb_to_yuv((255, 0, 0)),
+        (81, 90, 240) // 240 is the full color difference
+    );
+    assert_eq!(rgb_to_yuv((0, 255, 0)), (145, 54, 34));
+    assert_eq!(
+        rgb_to_yuv((0, 0, 255)),
+        (41, 240, 110) // 240 is the full color difference
+    );
+
+    assert_eq!(
+        rgb_to_yuv((0, 255, 255)),
+        (170, 166, 16) // 16 is the full color difference
+    );
+    assert_eq!(rgb_to_yuv((255, 0, 255)), (106, 202, 222));
+    assert_eq!(
+        rgb_to_yuv((255, 255, 0)),
+        (210, 16, 146) // 16 is the full color difference
+    );
+}
+
+#[test]
+fn test_rgb_yuv_rgb_roundtrip_sanity() {
+    assert_eq!(yuv_to_rgb(rgb_to_yuv((0, 0, 0)), &LUTS), (0, 0, 0));
+    assert_eq!(
+        yuv_to_rgb(rgb_to_yuv((127, 127, 127)), &LUTS),
+        (127, 127, 127)
+    );
+    assert_eq!(
+        yuv_to_rgb(rgb_to_yuv((128, 128, 128)), &LUTS),
+        (128, 128, 128)
+    );
+    assert_eq!(
+        yuv_to_rgb(rgb_to_yuv((255, 255, 255)), &LUTS),
+        (255, 255, 255)
+    );
+
+    assert_eq!(
+        yuv_to_rgb(rgb_to_yuv((255, 0, 0)), &LUTS),
+        (254, 0, 0) // !!! there is a rounding error here
+    );
+    assert_eq!(
+        yuv_to_rgb(rgb_to_yuv((0, 255, 0)), &LUTS),
+        (0, 255, 1) // !!! there is a rounding error here
+    );
+    assert_eq!(
+        yuv_to_rgb(rgb_to_yuv((0, 0, 255)), &LUTS),
+        (0, 0, 255) // there is NO rounding error here
+    );
+}
+
 #[test]
 fn test_lerp_chroma() {
     assert_eq!(lerp_chroma(&(0, 0, 0), &(0, 0, 0)), (0, 0, 0));
@@ -579,6 +655,40 @@ fn test_yuv420_to_rgba() {
         vec![
             0u8,     0u8,   0u8, 255u8, 255u8, 255u8, 255u8, 255u8,
             255u8, 255u8, 255u8, 255u8,   0u8,   0u8,   0u8, 255u8,
+        ]
+    );
+
+    // a 3x2 picture, black on the left, white on the right, grey in the middle
+    #[rustfmt::skip]
+    assert_eq!(
+        yuv420_to_rgba(&[0u8, 125u8, 235u8,  0u8, 125u8, 235u8], &[128u8, 128u8, ], &[128u8, 128u8,], 3, 2),
+        vec![
+            0u8,     0u8,   0u8, 255u8,  127u8, 127u8, 127u8, 255u8,  255u8, 255u8, 255u8, 255u8,
+            0u8,     0u8,   0u8, 255u8,  127u8, 127u8, 127u8, 255u8,  255u8, 255u8, 255u8, 255u8,
+        ]
+    );
+
+    // notes:
+    // (81, 90, 240) is full red in YUV
+    // (145, 54, 34) is full green in YUV
+
+    // A 3x3 picture, red on the top, green on the bottom.
+    // This has a 2x2 "bulk" processing group in it on the bottom right.
+    #[rustfmt::skip]
+    assert_eq!(
+        yuv420_to_rgba(
+            &[ 81u8,  81u8,  81u8,
+              125u8, 125u8, 125u8,
+              145u8, 145u8, 145u8],
+            &[ 90u8,  90u8,
+               54u8,  54u8],
+            &[240u8,  240u8,
+               34u8,  34u8],
+            3, 2),
+        vec![
+            254,   0,   0, 255,  254,   0,   0, 255,  254,   0,   0, 255, // red
+            224,  96,  32, 255,  224,  96,  32, 255,  224,  96,  32, 255, // orange
+             83, 210,  19, 255,   83, 210,  19, 255,   83, 210,  19, 255, // green
         ]
     );
 }

--- a/yuv/src/bt601.rs
+++ b/yuv/src/bt601.rs
@@ -2,88 +2,6 @@
 
 use lazy_static::lazy_static;
 
-fn clamped_index(width: i32, height: i32, x: i32, y: i32) -> usize {
-    (x.clamp(0, width - 1) + (y.clamp(0, height - 1) * width)) as usize
-}
-
-fn unclamped_index(width: i32, x: i32, y: i32) -> usize {
-    (x + y * width) as usize
-}
-
-fn sample_chroma_for_luma(
-    chroma: &[u8],
-    chroma_width: usize,
-    chroma_height: usize,
-    luma_x: usize,
-    luma_y: usize,
-    clamp: bool,
-) -> u8 {
-    let width = chroma_width as i32;
-    let height = chroma_height as i32;
-
-    let sample_00;
-    let sample_01;
-    let sample_10;
-    let sample_11;
-
-    if clamp {
-        let chroma_x = if luma_x == 0 {
-            -1
-        } else {
-            (luma_x as i32 - 1) / 2
-        };
-        let chroma_y = if luma_y == 0 {
-            -1
-        } else {
-            (luma_y as i32 - 1) / 2
-        };
-
-        sample_00 = chroma
-            .get(clamped_index(width, height, chroma_x, chroma_y))
-            .copied()
-            .unwrap_or(0) as u16;
-        sample_10 = chroma
-            .get(clamped_index(width, height, chroma_x + 1, chroma_y))
-            .copied()
-            .unwrap_or(0) as u16;
-        sample_01 = chroma
-            .get(clamped_index(width, height, chroma_x, chroma_y + 1))
-            .copied()
-            .unwrap_or(0) as u16;
-        sample_11 = chroma
-            .get(clamped_index(width, height, chroma_x + 1, chroma_y + 1))
-            .copied()
-            .unwrap_or(0) as u16;
-    } else {
-        let chroma_x = (luma_x as i32 - 1) / 2;
-        let chroma_y = (luma_y as i32 - 1) / 2;
-
-        let base = unclamped_index(width, chroma_x, chroma_y);
-        sample_00 = chroma.get(base).copied().unwrap_or(0) as u16;
-        sample_10 = chroma.get(base + 1).copied().unwrap_or(0) as u16;
-        sample_01 = chroma.get(base + chroma_width).copied().unwrap_or(0) as u16;
-        sample_11 = chroma.get(base + chroma_width + 1).copied().unwrap_or(0) as u16;
-    }
-
-    let interp_left = luma_x % 2 != 0;
-    let interp_top = luma_y % 2 != 0;
-
-    let mut sample: u16 = 0;
-    sample += sample_00 * if interp_left { 3 } else { 1 };
-    sample += sample_10 * if interp_left { 1 } else { 3 };
-
-    sample += sample_01 * if interp_left { 3 } else { 1 };
-    sample += sample_11 * if interp_left { 1 } else { 3 };
-
-    sample += sample_00 * if interp_top { 3 } else { 1 };
-    sample += sample_01 * if interp_top { 1 } else { 3 };
-
-    sample += sample_10 * if interp_top { 3 } else { 1 };
-    sample += sample_11 * if interp_top { 1 } else { 3 };
-
-    ((sample + 8) / 16) as u8
-}
-
 /// Precomputes and stores the linear functions for converting YUV (YCb'Cr' to be precise)
 /// colors to RGB (sRGB-like, with gamma) colors, in signed 12.4 fixed-point integer format.
 ///
@@ -147,15 +65,8 @@ lazy_static! {
 }
 
 #[inline]
-fn convert_and_write_pixel(
-    yuv: (u8, u8, u8),
-    rgba: &mut Vec<u8>,
-    width: usize,
-    x_pos: usize,
-    y_pos: usize,
-    luts: &LUTs,
-) {
-    let (y_sample, b_sample, r_sample) = yuv;
+fn yuv_to_rgb(yuv: (u8, u8, u8), luts: &LUTs) -> (u8, u8, u8) {
+    let (y, cb, cr) = yuv;
 
     // We rely on the optimizers in rustc/LLVM to eliminate the bounds checks when indexing
     // into the fixed 256-long arrays in `luts` with indices coming in as `u8` parameters.
@@ -163,25 +74,256 @@ fn convert_and_write_pixel(
     // I verified that this is actually happening, see here: https://rust.godbolt.org/z/vWzesYzbq
     // And benchmarking showed no time difference from an `unsafe` + `get_unchecked()` solution.
 
-    let y = luts.y_to_gray[y_sample as usize];
+    let gray = luts.y_to_gray[y as usize];
 
     // The `(... + 8) >> 4` parts convert back from 12.4 fixed-point to `u8` with correct rounding.
     // (At least for positive numbers - any negative numbers that might occur will be clamped to 0 anyway.)
-    let r = (y + luts.cr_to_r[r_sample as usize] + 8) >> 4;
-    let g = (y + luts.cr_to_g[r_sample as usize] + luts.cb_to_g[b_sample as usize] + 8) >> 4;
-    let b = (y + luts.cb_to_b[b_sample as usize] + 8) >> 4;
+    let r = (gray + luts.cr_to_r[cr as usize] + 8) >> 4;
+    let g = (gray + luts.cr_to_g[cr as usize] + luts.cb_to_g[cb as usize] + 8) >> 4;
+    let b = (gray + luts.cb_to_b[cb as usize] + 8) >> 4;
 
-    let base = (x_pos + y_pos * width) * 4;
-    rgba[base] = r.clamp(0, 255) as u8;
-    rgba[base + 1] = g.clamp(0, 255) as u8;
-    rgba[base + 2] = b.clamp(0, 255) as u8;
+    (
+        r.clamp(0, 255) as u8,
+        g.clamp(0, 255) as u8,
+        b.clamp(0, 255) as u8,
+    )
 }
 
-/// Convert YUV 4:2:0 data into RGB 1:1:1 data.
+/// Performs a linear interpolation with fixed t=0.25 between a and b,
+/// but only their .1 and .2 components, with proper rounding.
+/// a.0 is passed through as the .0 component of the result without
+/// touching it, and b.0 is completely ignored.
+///
+/// The naming refers to its practical use on (Y, Cb', Cr') color tuples.
+#[inline]
+fn lerp_chroma(a: &(u8, u8, u8), b: &(u8, u8, u8)) -> (u8, u8, u8) {
+    let cb = a.1 as u16;
+    let cr = a.2 as u16;
+
+    let new_cb = (cb + cb + cb + b.1 as u16 + 2) / 4;
+    let new_cr = (cr + cr + cr + b.2 as u16 + 2) / 4;
+
+    (a.0, new_cb as u8, new_cr as u8)
+}
+
+/// Similar to `lerp_chroma`, but the interpolated components of the result
+/// (.1 and .2) are not rounded and divided by 4, to keep more precision.
+/// So they are returned as `u16`, having 4 times the value they actually
+/// should - or you can think of them as being in 14.2 fixed-point format.
+#[inline]
+fn bilerp_chroma_step1(a: &(u8, u8, u8), b: &(u8, u8, u8)) -> (u8, u16, u16) {
+    let cb = a.1 as u16;
+    let cr = a.2 as u16;
+
+    let new_cb = cb + cb + cb + b.1 as u16;
+    let new_cr = cr + cr + cr + b.2 as u16;
+
+    (a.0, new_cb, new_cr)
+}
+
+/// Similar to `lerp_chroma`, but takes the parameters in the format as returned
+/// by `bilerp_chroma_step1`. At the end, it performs the rounding and division on
+/// the interpolated components, so converts them back to the regular `u8` format.
+#[inline]
+fn bilerp_chroma_step2(a: &(u8, u16, u16), b: &(u8, u16, u16)) -> (u8, u8, u8) {
+    // The division by 4 has to be done twice at this point, hence the / 16,
+    // and the + 8 is for correct rounding.
+    let new_cb = (a.1 + a.1 + a.1 + b.1 + 8) / 16;
+    let new_cr = (a.2 + a.2 + a.2 + b.2 + 8) / 16;
+
+    (a.0, new_cb as u8, new_cr as u8)
+}
+
+/// Returns two subslices of `of` as a tuple. Both are `width` long.
+/// The first one starts at the index `start`, and the second one at `start + stride`.
+/// Note that even if `of` is considered a 2D array of `stride` width, the "rows"
+/// returned by this function might not match to entire rows of that array,
+/// specifically to allow for margins on the left and/or right as well.
+///
+/// Preconditions:
+///  - `start + width <= of.len()`
+///  - `start + stride + width <= of.len()`
+///  - `stride >= width`
+#[inline]
+fn get_two_rows(of: &[u8], start: usize, width: usize, stride: usize) -> (&[u8], &[u8]) {
+    debug_assert!(start + width <= of.len());
+    debug_assert!(start + stride + width <= of.len());
+    debug_assert!(stride >= width);
+
+    let (top_row, rest): (&[u8], &[u8]) = (&of[start..]).split_at(width);
+    // `width` number of elements are already split off into `top_row`,
+    // so only the difference has to be skipped here.
+    // And for the end index, `(stride - width) + width` works out to just `stride`.
+    let bottom_row: &[u8] = &rest[(stride - width)..stride];
+    (top_row, bottom_row)
+}
+
+/// Similar to `get_two_rows`, but the slices going in and out are all `mut`.
+#[inline]
+fn get_two_rows_mut(
+    of: &mut [u8],
+    start: usize,
+    width: usize,
+    stride: usize,
+) -> (&mut [u8], &mut [u8]) {
+    debug_assert!(start + width <= of.len());
+    debug_assert!(start + stride + width <= of.len());
+    debug_assert!(stride >= width);
+
+    let (top_row, rest): (&mut [u8], &mut [u8]) = (&mut of[start..]).split_at_mut(width);
+    // `width` number of elements are already split off into `top_row`,
+    // so only the difference has to be skipped here.
+    // And for the end index, `(stride - width) + width` works out to just `stride`.
+    let bottom_row: &mut [u8] = &mut rest[(stride - width)..stride];
+    (top_row, bottom_row)
+}
+
+/// The y, chroma_b, chroma_r, y_width, br_width parameters must obey the same
+/// requirements as in `yuv420_to_rgba`.
+/// Plus:
+///  - `row` must be either 0 or y_height-1.
+///  - `y_height` (computed) must be even
+///
+/// Interpolation is only done horiztonally. Always exactly one row of chroma
+/// samples are used, either the first or the last.
+#[inline]
+#[allow(clippy::too_many_arguments)]
+fn process_edge_row(
+    y: &[u8],
+    chroma_b: &[u8],
+    chroma_r: &[u8],
+    y_width: usize,
+    br_width: usize,
+    rgba: &mut [u8],
+    row: usize,
+    luts: &LUTs,
+) {
+    debug_assert!(row == 0 || ((row == (y.len() / y_width) - 1) && (row % 2 == 1)));
+
+    // The first column is always skipped
+    let y_from = row * y_width + 1;
+    // Between all horizontal pairs of chroma samples, processing two luma samples (or pixels, if you like)
+    let y_to = y_from + (br_width - 1) * 2;
+
+    // For the top row, this will of course yield the first chroma row (index 0, below the first luma row);
+    // and for the last row (as its index must be odd), it will be rounded down after division, so the last
+    // chroma row will be used (above the last luma row) without overflow.
+    let br_from = (row / 2) * br_width;
+    let br_to = br_from + br_width;
+
+    let rgba_from = y_from * 4;
+    let rgba_to = y_to * 4;
+
+    let y_iter = (&y[y_from..y_to]).chunks(2);
+    let cb_iter = (&chroma_b[br_from..br_to]).windows(2);
+    let cr_iter = (&chroma_r[br_from..br_to]).windows(2);
+    let rgba_iter = (&mut rgba[rgba_from..rgba_to]).chunks_mut(8);
+
+    for (((y, cb), cr), rgba) in y_iter.zip(cb_iter).zip(cr_iter).zip(rgba_iter) {
+        let left = (y[0], cb[0], cr[0]);
+        let right = (y[1], cb[1], cr[1]);
+
+        let left_rgb = yuv_to_rgb(lerp_chroma(&left, &right), luts);
+        let right_rgb = yuv_to_rgb(lerp_chroma(&right, &left), luts);
+
+        rgba.copy_from_slice(&[
+            left_rgb.0,
+            left_rgb.1,
+            left_rgb.2,
+            255,
+            right_rgb.0,
+            right_rgb.1,
+            right_rgb.2,
+            255,
+        ]);
+    }
+}
+
+/// Converts either the leftmost or the rightmost column of pixels from
+/// YUV 4:2:0 to RGBA (the latter ony), using linear interpolation
+/// on the chroma samples.
+///
+/// The y, chroma_b, chroma_r, y_width, br_width parameters must obey the same
+/// requirements as for `yuv420_to_rgba`, plus:
+///  - `col` must be either 0 or y_width-1
+///  - y_width must be even
+///  - none of y_width, br_width, y_height, or br_height can be 0
+#[inline]
+#[allow(clippy::too_many_arguments)]
+fn process_edge_col(
+    y: &[u8],
+    chroma_b: &[u8],
+    chroma_r: &[u8],
+    y_width: usize,
+    br_width: usize,
+    rgba: &mut [u8],
+    col: usize,
+    luts: &LUTs,
+) {
+    debug_assert!(col == 0 || ((col == y_width - 1) && (col % 2 == 1)));
+
+    let y_height = y.len() / y_width;
+    let br_height = chroma_b.len() / br_width;
+
+    // This will be rounded down for rightmost columns, which is what we want.
+    let br_col = col / 2;
+
+    // The topmost pixels of these columns are special, there is no need for interpolation there.
+    let top_rgb = yuv_to_rgb((y[col], chroma_b[br_col], chroma_r[br_col]), luts);
+    rgba[col * 4..(col + 1) * 4].copy_from_slice(&[top_rgb.0, top_rgb.1, top_rgb.2, 255]);
+
+    // Processing two pixels at a time, between all vertical pairs of chroma samples.
+    // Instead of iterating with plain numbers and computing indices by hand, something could probably
+    // be figured out using step_by, but this should be good enough for these minority of pixels.
+    for br_y in 0..br_height - 1 {
+        // Skipping the topmost pixel here
+        let y_top_y = (br_y * 2) + 1;
+
+        let top_yuv = (
+            y[y_top_y * y_width + col],
+            chroma_b[br_y * br_width + br_col],
+            chroma_r[br_y * br_width + br_col],
+        );
+        let bottom_yuv = (
+            y[(y_top_y + 1) * y_width + col],
+            chroma_b[(br_y + 1) * br_width + br_col],
+            chroma_r[(br_y + 1) * br_width + br_col],
+        );
+
+        let top_rgb = yuv_to_rgb(lerp_chroma(&top_yuv, &bottom_yuv), luts);
+        let bottom_rgb = yuv_to_rgb(lerp_chroma(&bottom_yuv, &top_yuv), luts);
+
+        rgba[(y_top_y * y_width + col) * 4..(y_top_y * y_width + col + 1) * 4]
+            .copy_from_slice(&[top_rgb.0, top_rgb.1, top_rgb.2, 255]);
+        rgba[((y_top_y + 1) * y_width + col) * 4..((y_top_y + 1) * y_width + col + 1) * 4]
+            .copy_from_slice(&[bottom_rgb.0, bottom_rgb.1, bottom_rgb.2, 255]);
+    }
+
+    // Finally processing the bottom pixel, if needed
+    if (y_height % 2) == 0 {
+        let y_index = (y_height - 1) * y_width + col;
+        let br_index = (br_height - 1) * br_width + br_col;
+        // The top pixel is also special, there is no need for interpolation here either.
+        let rgb = yuv_to_rgb((y[y_index], chroma_b[br_index], chroma_r[br_index]), luts);
+        rgba[y_index * 4..(y_index + 1) * 4].copy_from_slice(&[rgb.0, rgb.1, rgb.2, 255]);
+    }
+}
+
+/// Convert planar YUV 4:2:0 data into interleaved RGBA 8888 data.
 ///
 /// This function yields an RGBA picture with the same number of pixels as were
 /// provided in the `y` picture. The `b` and `r` pictures will be resampled at
 /// this stage, and the resulting picture will have color components mixed.
+///
+/// Preconditions:
+///  - `y.len()` must be an integer multiple of `y_width`
+///  - `chroma_b.len()` and `chroma_r.len()` must both be integer multiples of `br_width`
+///  - `chroma_b` and `chroma_r` must be the same size
+///  - If `y_width` is even, `br_width` must be `y_width / 2`, otherwise, `(y_width + 1) / 2`
+///  - With `y_height` computed as `y.len() / y_width`, and `br_height` as `chroma_b.len() / br_width`:
+///    If `y_height` is even, `br_height` must be `y_height / 2`, otherwise, `(y_height + 1) / 2`
+///    (So, either there is an "outer" column/row of luma samples on the right/bottom (similar to how
+///    there always is on the left/top) or they are cut off - independently of each other)
 pub fn yuv420_to_rgba(
     y: &[u8],
     chroma_b: &[u8],
@@ -189,73 +331,165 @@ pub fn yuv420_to_rgba(
     y_width: usize,
     br_width: usize,
 ) -> Vec<u8> {
+    debug_assert_eq!(y.len() % y_width, 0);
+    debug_assert_eq!(chroma_b.len() % br_width, 0);
+    debug_assert_eq!(chroma_r.len() % br_width, 0);
+    debug_assert_eq!(chroma_b.len(), chroma_r.len());
+
+    // Shortcut for the no-op case to avoid all kinds of overflows below
+    if y.is_empty() {
+        return vec![];
+    }
+
     let y_height = y.len() / y_width;
     let br_height = chroma_b.len() / br_width;
 
-    // prefilling with 255, so the tight loop won't need to write to the alpha channel
-    let mut rgba = vec![255; y.len() * 4];
+    // the + 1 will be dropped after division for even sizes
+    debug_assert_eq!((y_width + 1) / 2, br_width);
+    debug_assert_eq!((y_height + 1) / 2, br_height);
+
+    let mut rgba = vec![0; y.len() * 4];
+    let rgba_stride = y_width * 4; // 4 bytes per pixel, interleaved
 
     // making sure that the "is it initialized already?" check is only done once per frame by getting a direct reference
     let luts: &LUTs = &*LUTS;
 
-    // do the bulk of the pixels faster, with no clamping, leaving out the edges
-    for y_pos in 1..y_height - 1 {
-        for x_pos in 1..y_width - 1 {
-            let y_sample = y.get(x_pos + y_pos * y_width).copied().unwrap_or(0);
-            let b_sample =
-                sample_chroma_for_luma(chroma_b, br_width, br_height, x_pos, y_pos, false);
-            let r_sample =
-                sample_chroma_for_luma(chroma_r, br_width, br_height, x_pos, y_pos, false);
+    // About the algorithm below:
+    //
+    // Consider Figure 2/H.263 in the ITU-T H.263 Recommendation.
+    //
+    // Every iteration below works with a 2x2 "bunch" of neighbouring chrominance samples,
+    // and the 2x2 luminance samples "enclosed by" these chrominance samples; writing to
+    // the 2x2 output pixels in the same location in the picture as the luminance samples.
+    //
+    // This means that the topmost row and the leftmost column of output pixels is not covered
+    // by this loop. On pictures of even width, the rightmost column isn't covered either;
+    // and similarly, on pictures of even height, the bottommost row is left out as well.
+    //
+    // Initially, the chrominance samples are "further out" of these 2x2 rectangles than they
+    // should be, so they are bilinearly interpolated to the location of the luminance samples.
 
-            convert_and_write_pixel(
-                (y_sample, b_sample, r_sample),
-                &mut rgba,
-                y_width,
-                x_pos,
-                y_pos,
-                luts,
-            );
+    // Iteration is done in a row-major order to fit the slice layouts.
+    for chroma_row in 0..br_height - 1 {
+        // Selecting two consecutive rows from all 3 input and the output slices to work with.
+        // The top row of Y and RGBA has to be skipped, as well as the first sample/pixel of
+        // each row. The width of the Y and RGBA rows is derived from br_width to make the
+        // parity of y_width irrelevant.
+        let luma_row = chroma_row * 2 + 1;
+
+        let (y_upper, y_lower) =
+            get_two_rows(y, luma_row * y_width + 1, 2 * (br_width - 1), y_width);
+        let (cb_upper, cb_lower) =
+            get_two_rows(chroma_b, chroma_row * br_width, br_width, br_width);
+        let (cr_upper, cr_lower) =
+            get_two_rows(chroma_r, chroma_row * br_width, br_width, br_width);
+        let (rgba_upper, rgba_lower) = get_two_rows_mut(
+            &mut rgba,
+            luma_row * rgba_stride + 4,
+            2 * (br_width - 1) * 4,
+            rgba_stride,
+        );
+
+        // The Cb and Cr data has to be iterated on with overlaps, while every sample or pixel
+        // of Y and RGBA data only has to be touched in one iteration.
+        let y_iter = y_upper.chunks(2).zip(y_lower.chunks(2));
+        let cb_iter = cb_upper.windows(2).zip(cb_lower.windows(2));
+        let cr_iter = cr_upper.windows(2).zip(cr_lower.windows(2));
+        // Similar to how Y is iterated on, but with 4 channels per pixel
+        let rgba_iter = rgba_upper.chunks_mut(8).zip(rgba_lower.chunks_mut(8));
+
+        for ((((y_u, y_l), (cb_u, cb_l)), (cr_u, cr_l)), (rgba_u, rgba_l)) in
+            y_iter.zip(cb_iter).zip(cr_iter).zip(rgba_iter)
+        {
+            let topleft = (y_u[0], cb_u[0], cr_u[0]);
+            let bottomleft = (y_l[0], cb_l[0], cr_l[0]);
+
+            let topright = (y_u[1], cb_u[1], cr_u[1]);
+            let bottomright = (y_l[1], cb_l[1], cr_l[1]);
+
+            // Bringing in the chroma components to where they should be horizontally
+            let topleft_intermediate = bilerp_chroma_step1(&topleft, &topright);
+            let topright_intermediate = bilerp_chroma_step1(&topright, &topleft);
+
+            let bottomleft_intermediate = bilerp_chroma_step1(&bottomleft, &bottomright);
+            let bottomright_intermediate = bilerp_chroma_step1(&bottomright, &bottomleft);
+
+            // Then putting them in the right place vertically as well
+            let topleft_final =
+                bilerp_chroma_step2(&topleft_intermediate, &bottomleft_intermediate);
+            let bottomleft_final =
+                bilerp_chroma_step2(&bottomleft_intermediate, &topleft_intermediate);
+
+            let topright_final =
+                bilerp_chroma_step2(&topright_intermediate, &bottomright_intermediate);
+            let bottomright_final =
+                bilerp_chroma_step2(&bottomright_intermediate, &topright_intermediate);
+
+            // Now the colorspace conversion can be done on the colocated components
+            let topleft_rgb = yuv_to_rgb(topleft_final, luts);
+            let topright_rgb = yuv_to_rgb(topright_final, luts);
+
+            let bottomleft_rgb = yuv_to_rgb(bottomleft_final, luts);
+            let bottomright_rgb = yuv_to_rgb(bottomright_final, luts);
+
+            // Finally they are written into the output array, with fixed A values
+            rgba_u.copy_from_slice(&[
+                topleft_rgb.0,
+                topleft_rgb.1,
+                topleft_rgb.2,
+                255,
+                topright_rgb.0,
+                topright_rgb.1,
+                topright_rgb.2,
+                255,
+            ]);
+            rgba_l.copy_from_slice(&[
+                bottomleft_rgb.0,
+                bottomleft_rgb.1,
+                bottomleft_rgb.2,
+                255,
+                bottomright_rgb.0,
+                bottomright_rgb.1,
+                bottomright_rgb.2,
+                255,
+            ]);
+
+            // Note: The unmodified "right" chroma components (both top and bottom, both cb and cr) could
+            // potentially be reused in the next iteration as "left" components, thus removing the need to
+            // iterate on 2-long windows of these slices, but I think everything is clearer this way.
         }
     }
 
-    // doing the sides with clamping
-    for y_pos in 0..y_height {
-        for x_pos in [0, y_width - 1].iter() {
-            let y_sample = y.get(x_pos + y_pos * y_width).copied().unwrap_or(0);
-            let b_sample =
-                sample_chroma_for_luma(chroma_b, br_width, br_height, *x_pos, y_pos, true);
-            let r_sample =
-                sample_chroma_for_luma(chroma_r, br_width, br_height, *x_pos, y_pos, true);
-
-            convert_and_write_pixel(
-                (y_sample, b_sample, r_sample),
-                &mut rgba,
-                y_width,
-                *x_pos,
-                y_pos,
-                luts,
-            );
-        }
+    // The top row always needs to be processed separately (this still excludes the corner pixels)
+    process_edge_row(y, chroma_b, chroma_r, y_width, br_width, &mut rgba, 0, luts);
+    // On pictures of even height, the bottom row as well
+    if (y_height % 2) == 0 {
+        process_edge_row(
+            y,
+            chroma_b,
+            chroma_r,
+            y_width,
+            br_width,
+            &mut rgba,
+            y_height - 1,
+            luts,
+        );
     }
 
-    // doing the top and bottom edges with clamping
-    for y_pos in [0, y_height - 1].iter() {
-        for x_pos in 0..y_width {
-            let y_sample = y.get(x_pos + y_pos * y_width).copied().unwrap_or(0);
-            let b_sample =
-                sample_chroma_for_luma(chroma_b, br_width, br_height, x_pos, *y_pos, true);
-            let r_sample =
-                sample_chroma_for_luma(chroma_r, br_width, br_height, x_pos, *y_pos, true);
-
-            convert_and_write_pixel(
-                (y_sample, b_sample, r_sample),
-                &mut rgba,
-                y_width,
-                x_pos,
-                *y_pos,
-                luts,
-            );
-        }
+    // The left column always needs to be processed separately (this will finally deal with the corner pixels)
+    process_edge_col(y, chroma_b, chroma_r, y_width, br_width, &mut rgba, 0, luts);
+    // On pictures of even width, the right column as well
+    if (y_width % 2) == 0 {
+        process_edge_col(
+            y,
+            chroma_b,
+            chroma_r,
+            y_width,
+            br_width,
+            &mut rgba,
+            y_width - 1,
+            luts,
+        );
     }
 
     rgba


### PR DESCRIPTION
Instead of iterating on plain numbers and computing array indices manually (hence forcing continuous bounds checks everywhere), a parallel iteration scheme is set up on two consecutive lines of all three input, and the output array, at once. Each of these iterators yields two neighboring samples/pixels to work with (in a nice, symmetric, square arrangement), so with each iteration we have 4 of every operand.

There is no clipping of coordinates anywhere, as they are not needed - the pixels are split into 3 different "classes" (bulk, edge, corner; with bilinear, linear, and no interpolation; in this order), and indexing for them is always handled appropriately. There is also not a single `unsafe` in sight, yay!

The two-stage bilinear interpolation (with wider intermediates) results in only one division per pixel, instead of two, which is nice.

~~Please don't look at the commit history just yet, I'll squash it neatly once everything works well.
Benchmark numbers and fancy explainer diagrams will follow. I expect around an *overall* 15% speedup yet again, as measured on three hand-picked z0r loops.~~
EDIT: Commit history cleaned up, benchmarks and explainers added.

~~Note that the indexing in `process_edge_col` is simply **WRONG** right now, so the left and right (one or two) columns of pixels are incorrect in the output.~~
EDIT: This is fixed.

The processing of 4 pixels at a time in an identical manner (just in different "directions") also lends itself nicely to SIMD in the future (perhaps even to autovectorization right now, but I haven't checked that), although 16 bit operands on 4 parallel lanes is still only 64 bits total, which is half of the 128 bits available in WASM SIMD.

This supersedes #6.