### PR TITLE
yuv: Remove chroma interpolation, use iterators

### DIFF
--- a/yuv/src/bt601.rs
+++ b/yuv/src/bt601.rs
@@ -153,19 +153,20 @@ lazy_static! {
 
 #[inline]
 fn yuv_to_rgb(yuv: (u8, u8, u8), luts: &LUTs) -> (u8, u8, u8) {
+    let (y, cb, cr) = yuv;
+
     // We rely on the optimizers in rustc/LLVM to eliminate the bounds checks when indexing
     // into the fixed 256-long arrays in `luts` with indices coming in as `u8` parameters.
     // This is crucial for performance, as this function runs in a fairly tight loop, on all pixels.
     // I verified that this is actually happening, see here: https://rust.godbolt.org/z/vWzesYzbq
     // And benchmarking showed no time difference from an `unsafe` + `get_unchecked()` solution.
-
-    let y = luts.y_to_gray[yuv.0 as usize];
+    let gray = luts.y_to_gray[y as usize];
 
     // The `(... + 8) >> 4` parts convert back from 12.4 fixed-point to `u8` with correct rounding.
     // (At least for positive numbers - any negative numbers that might occur will be clamped to 0 anyway.)
-    let r = (y + luts.cr_to_r[yuv.2 as usize] + 8) >> 4;
-    let g = (y + luts.cr_to_g[yuv.2 as usize] + luts.cb_to_g[yuv.1 as usize] + 8) >> 4;
-    let b = (y + luts.cb_to_b[yuv.1 as usize] + 8) >> 4;
+    let r = (gray + luts.cr_to_r[cr as usize] + 8) >> 4;
+    let g = (gray + luts.cr_to_g[cr as usize] + luts.cb_to_g[cb as usize] + 8) >> 4;
+    let b = (gray + luts.cb_to_b[cb as usize] + 8) >> 4;
 
     (
         r.clamp(0, 255) as u8,


### PR DESCRIPTION
Sadly, this effectively reverts https://github.com/kmeisthax/ruffle/pull/10.
This is technically less "correct", and looks less nice, but in exchange, we gain a whole bunch of speed, the original code simplicity, and most importantly, close similarity to Flash Player.
It also replaces #9, being much-much simpler than that.

To verify, take this test video: [testpattern6_h263.zip](https://github.com/ruffle-rs/h263-rs/files/7228880/testpattern6_h263.zip)

(All screenshots are in 5x magnification with "nearest" interpolation.)
 
This is how it looks in Adobe Flash Player:
![image](https://user-images.githubusercontent.com/288816/134751807-c0e0b40f-a193-4935-8cc8-8c6a1c865c5a.png)
Notice how the top vertical red bar is precisely two pixels wide, with no bleeding to the left or right at all.

(The slightly off-shade blue bars above and below the left horizontal red bar are the result of FFmpeg's RGB->YUV conversion. They are there even when I convert the same source image into raw .y4m with yuv420p pixel format.)

This is how it looks in Ruffle now:
![image](https://user-images.githubusercontent.com/288816/134751830-e9cbc146-4f76-41e7-b3cd-c51b97ac8e9a.png)

And in Ruffle, with this change:
![image](https://user-images.githubusercontent.com/288816/134751862-4313ae43-a5e0-4ca2-9d92-d3604040e42d.png)

Basically identical to what Flash Player shows, except for some slight noise, most likely from the IDCT.
