### PR TITLE
h263: Swap the loops in `idct_1d` so it autovectorizes into SIMD nicely

### DIFF
--- a/h263/src/decoder/cpu/idct.rs
+++ b/h263/src/decoder/cpu/idct.rs
@@ -51,8 +51,9 @@ const BASIS_TABLE: [[f32; 8]; 8] = [
 /// for the scaling of the DC component, and for the cosine values to be used.
 fn idct_1d(input: &[f32; 8], output: &mut [f32; 8]) {
     *output = [0.0; 8];
-    for freq in 0..8 {
-        for (i, out) in output.iter_mut().enumerate() {
+    for (i, out) in output.iter_mut().enumerate() {
+        // Do your magic, autovectorizer! Thanks...
+        for freq in 0..8 {
             *out += input[freq] * BASIS_TABLE[freq][i];
         }
     }


### PR DESCRIPTION
This was discovered by @adrian17.

For such a simple change, it brings an almost 25% overall speedup on web, with the `simd128` target feature enabled, as most of the decoding time (about 65%) is now spent in the IDCT step, and this lets the compiler completely vectorize these loops (doing the inner one as a pair of `f32x4` mul+add combos), making them a lot faster.

Really nice improvement for such a small change!

This is how it looked so far: https://godbolt.org/z/KqW19nxEb
And this is with the change: https://godbolt.org/z/bzr6abh7Y

Even without any wasm extensions (so, using the vanilla module), this brings an overall speedup of about 10%, which is interesting.

I did try (also after @adrian17's advice) transposing the `BASIS_TABLE` constant, to see if the compiler can make even more improvements that way, but it didn't really help - if anything, it got slightly worse.