### PR TITLE
chore: Fix all new clippy lints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "autocfg"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "bitflags"
@@ -16,9 +16,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bytemuck"
-version = "1.7.2"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72957246c41db82b8ef88a5486143830adeb8227ef9837740bdec67724cf2c5b"
+checksum = "c041d3eab048880cb0b86b256447da3f18859a163c3b8d8893f4e6368abe6393"
 
 [[package]]
 name = "h263-rs"
@@ -46,27 +46,27 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "num-traits"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
+checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
 dependencies = [
  "autocfg",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.28"
+version = "1.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c7ed8b8c7b886ea3ed7dde405212185f423ab44682667c8c6dd14aa1d9f6612"
+checksum = "6ef7d57beacfaf2d8aee5937dab7b7f28de3cb8b1828479bb5de2a7106f2bae2"
 dependencies = [
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.9"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
+checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
 dependencies = [
  "proc-macro2",
 ]
@@ -82,29 +82,29 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.75"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7f58f7e8eaa0009c5fec437aabf511bd9933e4b2d7407bd05273c01a8906ea7"
+checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
 dependencies = [
  "proc-macro2",
  "quote",
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
 name = "thiserror"
-version = "1.0.30"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854babe52e4df1653706b98fcfc05843010039b406875930a70e4d9644e5c417"
+checksum = "6a9cd18aa97d5c45c6603caea1da6628790b37f7a34b6ca89522331c5180fed0"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.30"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa32fd3f627f367fe16f893e2597ae3c05020f8bba2666a4e6ea73d377e5714b"
+checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -112,16 +112,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.2"
+name = "unicode-ident"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
+checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
 
 [[package]]
 name = "wide"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3aba2d1dac31ac7cae82847ac5b8be822aee8f99a4e100f279605016b185c5f"
+checksum = "ae41ecad2489a1655c8ef8489444b0b113c0a0c795944a3572a0931cf7d2525c"
 dependencies = [
  "bytemuck",
  "safe_arch",

--- a/h263/src/decoder/cpu/idct.rs
+++ b/h263/src/decoder/cpu/idct.rs
@@ -1,7 +1,5 @@
 //! Inverse discrete cosine transform
 
-use std::cmp::{max, min};
-
 /*
 use lazy_static::lazy_static;
 use std::f32::consts::{FRAC_1_SQRT_2, PI};
@@ -123,12 +121,11 @@ pub fn idct_channel(
                         continue;
                     }
 
-                    let clipped_idct =
-                        min(255, max(-256, (idct / 4.0 + idct.signum() * 0.5) as i16));
+                    let clipped_idct = ((idct / 4.0 + idct.signum() * 0.5) as i16).clamp(-256, 255);
                     let mocomp_pixel = output[x + (y * output_samples_per_line)] as u16 as i16;
 
                     output[x + (y * output_samples_per_line)] =
-                        min(255, max(0, clipped_idct + mocomp_pixel)) as u8;
+                        (clipped_idct + mocomp_pixel).clamp(0, 255) as u8;
                 }
             }
         }

--- a/h263/src/decoder/cpu/mvd_pred.rs
+++ b/h263/src/decoder/cpu/mvd_pred.rs
@@ -34,7 +34,7 @@ pub fn predict_candidate(
     let col_index = current_mb % mb_per_line;
     let mv1_pred = match index {
         0 | 2 if col_index == 0 => MotionVector::zero(),
-        0 | 2 => predictor_vectors[current_mb as usize - 1][index + 1],
+        0 | 2 => predictor_vectors[current_mb - 1][index + 1],
         1 | 3 => current_predictors[index - 1],
         _ => unreachable!(),
     };

--- a/h263/src/decoder/cpu/rle.rs
+++ b/h263/src/decoder/cpu/rle.rs
@@ -1,7 +1,6 @@
 //! Block run decompression
 
 use crate::types::Block;
-use std::cmp::{max, min};
 
 const DEZIGZAG_MAPPING: [(u8, u8); 64] = [
     (0, 0),
@@ -106,11 +105,10 @@ pub fn inverse_rle(
         let dequantized_level = quant as i16 * ((2 * tcoef.level.abs()) + 1);
         let parity = if quant % 2 == 1 { 0 } else { -1 };
 
-        block[zig_x as usize][zig_y as usize] = min(
-            2047,
-            max(-2048, tcoef.level.signum() * (dequantized_level + parity)),
-        )
-        .into();
+        block[zig_x as usize][zig_y as usize] = (tcoef.level.signum()
+            * (dequantized_level + parity))
+            .clamp(-2048, 2047)
+            .into();
         zigzag_index += 1;
     }
 }

--- a/h263/src/decoder/state.rs
+++ b/h263/src/decoder/state.rs
@@ -9,7 +9,6 @@ use crate::types::{
     GroupOfBlocks, Macroblock, MacroblockType, MotionVector, Picture, PictureOption,
     PictureTypeCode, MPPTYPE_OPTIONS, OPPTYPE_OPTIONS,
 };
-use std::cmp::{max, min};
 use std::collections::HashMap;
 use std::io::Read;
 
@@ -224,7 +223,7 @@ impl H263State {
                         motion_vectors_b: _motion_vectors_b,
                     }) => {
                         let quantizer = in_force_quantizer as i8 + d_quantizer.unwrap_or(0);
-                        in_force_quantizer = max(1, min(31, quantizer)) as u8;
+                        in_force_quantizer = quantizer.clamp(1, 31) as u8;
 
                         if mb_type.is_inter() {
                             let mv1 = motion_vector.unwrap_or_else(MotionVector::zero);

--- a/h263/src/parser/reader.rs
+++ b/h263/src/parser/reader.rs
@@ -63,7 +63,7 @@ where
         let bits_available = (self.buffer.len() * 8).saturating_sub(self.bits_read);
         let bits_short = (bits_needed as usize).saturating_sub(bits_available);
 
-        (bits_short / 8) + if bits_short % 8 != 0 { 1 } else { 0 }
+        (bits_short / 8) + usize::from(bits_short % 8 != 0)
     }
 
     /// Ensure that at least a certain number of additional bits can be read

--- a/h263/src/types.rs
+++ b/h263/src/types.rs
@@ -912,7 +912,7 @@ impl IntraDc {
     /// This function yields `None` for out-of-range or otherwise
     /// unrepresentable level constants.
     pub fn from_level(value: u16) -> Option<Self> {
-        if (value & 0x07) != 0 || value > 2032 || value < 8 {
+        if (value & 0x07) != 0 || !(8..=2032).contains(&value) {
             return None;
         }
 

--- a/yuv/src/bt601.rs
+++ b/yuv/src/bt601.rs
@@ -87,7 +87,7 @@ fn yuv_to_rgb(yuv: (u8, u8, u8)) -> (u8, u8, u8) {
     assert!(rgba_4x[14] == rgba_4x[2]);
     assert!(rgba_4x[15] == 255);
 
-    (rgba_4x[0] as u8, rgba_4x[1] as u8, rgba_4x[2] as u8)
+    (rgba_4x[0], rgba_4x[1], rgba_4x[2])
 }
 
 /// Convert planar YUV 4:2:0 data into interleaved RGBA 8888 data.


### PR DESCRIPTION
So DependaBot can do its thing.
I don't necessarily agree with _all_ of the lints, such as `bool_to_int_with_if` or `manual_range_contains`, but I found it easier to just accept all of them blindly.