### PR TITLE
Add fast paths for some trivial special cases of the 2D IDCT

### DIFF
--- a/h263/src/decoder/cpu/idct.rs
+++ b/h263/src/decoder/cpu/idct.rs
@@ -128,6 +128,42 @@ pub fn idct_channel(
                         }
                     }
                 }
+                DecodedDctBlock::Horiz(first_row) => {
+                    idct_1d(first_row, &mut idct_intermediate[0]);
+
+                    for y_offset in 0..ys {
+                        for (x_offset, idct) in idct_intermediate[0].iter().take(xs).enumerate() {
+                            let x = x_base * 8 + x_offset;
+                            let y = y_base * 8 + y_offset;
+
+                            let clipped_idct =
+                                ((idct * BASIS_TABLE[0][0] / 4.0 + idct.signum() * 0.5) as i16)
+                                    .clamp(-256, 255);
+                            let mocomp_pixel = output[x + (y * output_samples_per_line)] as i16;
+
+                            output[x + (y * output_samples_per_line)] =
+                                (clipped_idct + mocomp_pixel).clamp(0, 255) as u8;
+                        }
+                    }
+                }
+                DecodedDctBlock::Vert(first_col) => {
+                    idct_1d(first_col, &mut idct_intermediate[0]);
+
+                    for (y_offset, idct) in idct_intermediate[0].iter().take(ys).enumerate() {
+                        for x_offset in 0..xs {
+                            let x = x_base * 8 + x_offset;
+                            let y = y_base * 8 + y_offset;
+
+                            let clipped_idct =
+                                ((idct * BASIS_TABLE[0][0] / 4.0 + idct.signum() * 0.5) as i16)
+                                    .clamp(-256, 255);
+                            let mocomp_pixel = output[x + (y * output_samples_per_line)] as i16;
+
+                            output[x + (y * output_samples_per_line)] =
+                                (clipped_idct + mocomp_pixel).clamp(0, 255) as u8;
+                        }
+                    }
+                }
                 DecodedDctBlock::Full(block_data) => {
                     for row in 0..8 {
                         idct_1d(&block_data[row], &mut idct_output[row]);

--- a/h263/src/decoder/cpu/rle.rs
+++ b/h263/src/decoder/cpu/rle.rs
@@ -91,7 +91,7 @@ pub fn inverse_rle(
 
     // Taking care of some special cases of outputs (IDCT inputs) first,
     // where at most the DC coefficient is present.
-    if encoded_block.tcoef.is_empty() {
+    *block = if encoded_block.tcoef.is_empty() {
         match encoded_block.intradc {
             Some(dc) => {
                 // The block is DC only.
@@ -100,10 +100,12 @@ pub fn inverse_rle(
                 if dc_level == 0 {
                     // This isn't really supposed to happen, but just in case...
                     // (If the DC coefficient is zero, it shouldn't have been coded.)
-                    *block = DecodedDctBlock::Zero
+                    DecodedDctBlock::Zero
+                } else {
+                    DecodedDctBlock::Dc(dc_level.into())
                 }
             }
-            None => *block = DecodedDctBlock::Zero, // The block is empty.
+            None => DecodedDctBlock::Zero, // The block is empty.
         }
     } else {
         // The slightly less special cases: `Horiz`, `Vert`, and `Full`.
@@ -131,6 +133,6 @@ pub fn inverse_rle(
             zigzag_index += 1;
         }
 
-        *block = DecodedDctBlock::Full(block_data);
+        DecodedDctBlock::Full(block_data)
     }
 }

--- a/h263/src/decoder/state.rs
+++ b/h263/src/decoder/state.rs
@@ -6,8 +6,8 @@ use crate::decoder::types::DecoderOption;
 use crate::error::{Error, Result};
 use crate::parser::{decode_block, decode_gob, decode_macroblock, decode_picture, H263Reader};
 use crate::types::{
-    GroupOfBlocks, Macroblock, MacroblockType, MotionVector, Picture, PictureOption,
-    PictureTypeCode, MPPTYPE_OPTIONS, OPPTYPE_OPTIONS,
+    DecodedDctBlock, GroupOfBlocks, Macroblock, MacroblockType, MotionVector, Picture,
+    PictureOption, PictureTypeCode, MPPTYPE_OPTIONS, OPPTYPE_OPTIONS,
 };
 use std::collections::HashMap;
 use std::io::Read;
@@ -183,11 +183,12 @@ impl H263State {
             let mut next_decoded_picture =
                 DecodedPicture::new(next_picture, format).ok_or(Error::PictureFormatInvalid)?;
 
-            let mut luma_levels = vec![[[0.0; 8]; 8]; level_dimensions.0 * level_dimensions.1 / 64];
+            let mut luma_levels =
+                vec![DecodedDctBlock::Zero; level_dimensions.0 * level_dimensions.1 / 64];
             let mut chroma_b_levels =
-                vec![[[0.0; 8]; 8]; level_dimensions.0 * level_dimensions.1 / 4 / 64];
+                vec![DecodedDctBlock::Zero; level_dimensions.0 * level_dimensions.1 / 4 / 64];
             let mut chroma_r_levels =
-                vec![[[0.0; 8]; 8]; level_dimensions.0 * level_dimensions.1 / 4 / 64];
+                vec![DecodedDctBlock::Zero; level_dimensions.0 * level_dimensions.1 / 4 / 64];
 
             loop {
                 let mb = decode_macroblock(

--- a/h263/src/types.rs
+++ b/h263/src/types.rs
@@ -900,6 +900,12 @@ pub enum DecodedDctBlock {
     /// The block only has a single non-zero element, in the top left corner
     /// (the DC component), so the IDCT output will be constant.
     Dc(f32),
+    /// The block only has non-zero elements in the first row, so only a single
+    /// 1D IDCT needs to be performed, the rest can be filled by copying.
+    Horiz([f32; 8]),
+    /// The block only has non-zero elements in the first column, so only a single
+    /// 1D IDCT needs to be performed, the rest can be filled by copying.
+    Vert([f32; 8]),
     /// The general case, a full 2D IDCT needs to be performed.
     Full([[f32; 8]; 8]),
 }

--- a/h263/src/types.rs
+++ b/h263/src/types.rs
@@ -887,6 +887,20 @@ pub struct Block {
     pub tcoef: Vec<TCoefficient>,
 }
 
+/// This type has nothing to do with H.263 itself, it's just to keep some trivial
+/// (or at least simpler) special cases of the IDCT inputs separate as an optimization.
+/// It's easier and faster to do it here instead of trying to detect them later.
+///
+/// NOTE: The `f32` values could later be changed to `i16` to save some memory.
+#[allow(clippy::large_enum_variant)] // The small variants are only used as markers.
+#[derive(Clone, Copy, Debug)]
+pub enum DecodedDctBlock {
+    /// The block is all zeros, it contributes nothing.
+    Zero,
+    /// The general case, a full 2D IDCT needs to be performed.
+    Full([[f32; 8]; 8]),
+}
+
 /// ITU-T Recommendation H.263 (01/2005) 5.4.1 `INTRADC`
 ///
 /// The DC coefficient for intra blocks is coded in a somewhat weird way; this

--- a/h263/src/types.rs
+++ b/h263/src/types.rs
@@ -897,6 +897,9 @@ pub struct Block {
 pub enum DecodedDctBlock {
     /// The block is all zeros, it contributes nothing.
     Zero,
+    /// The block only has a single non-zero element, in the top left corner
+    /// (the DC component), so the IDCT output will be constant.
+    Dc(f32),
     /// The general case, a full 2D IDCT needs to be performed.
     Full([[f32; 8]; 8]),
 }


### PR DESCRIPTION
The most time-consuming part of decoding frames at the moment is `idct_channel`. This PR makes it **a lot** faster.

It does so by classifying blocks into a few categories while undoing the RLE and zigzag transform, where the input of the block IDCT is created.
These categories are the following:
 - **Zero**: nothing to do, the output of the IDCT for this block would also be all zeroes
 - **Dc**: only the single top-left frequency component is non-zero, and this is also easy, the output is 64 times the same value
 - **Horiz**/**Vert**: only the top/left row/column has non-zero components, which means that only that row/column needs to be IDCT'd, and the block is DC in the other dimension
 - **Full**: none of the above conditions are met, doing the full 2D IDCT on it as before

The idea of doing _some_ shortcutting (for the zero/DC cases) here presented itself to me while reading https://github.com/etemesi254/zune-jpeg/blob/983dcdbcd8070bd33a018d1db6e20e801c30f902/src/idct/scalar.rs#L43-L75. But honestly, in hindsight, this is such an obvious and significant optimization that I'm surprised we didn't think of this before ourselves. And I'm sure it's used all over the place where image/video processing is going on.

The speedup this brings can be seen here:

![image](https://user-images.githubusercontent.com/288816/222929728-b08af213-3ebd-420a-ad38-4180a8156afe.png)

This is while playing the same video file, with the top chart showing the "before" and the bottom one the "after".

_As they say: The fastest way of doing something is not doing it at all._