### PR TITLE
build(deps): update bitflags requirement from 1.3.2 to 2.0.0

### DIFF
--- a/h263/Cargo.toml
+++ b/h263/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-bitflags = "1.3.2"
+bitflags = "2.0.0"
 thiserror = "1.0"
 num-traits = "0.2.15"
 lazy_static = "1.4.0"

--- a/h263/src/decoder/types.rs
+++ b/h263/src/decoder/types.rs
@@ -2,6 +2,7 @@
 
 bitflags! {
     /// Options which influence the decoding of a bitstream.
+    #[derive(Copy, Clone)]
     pub struct DecoderOption : u8 {
         /// Attempt to decode the video as a Sorenson Spark bitstream.
         ///

--- a/h263/src/parser/picture.rs
+++ b/h263/src/parser/picture.rs
@@ -87,6 +87,7 @@ bitflags! {
     /// requirement that `UFEP` equal 001. Otherwise, the existence of a
     /// follower can be determined by the set of `PictureOption`s returned in
     /// the `PlusPType`.
+    #[derive(Copy, Clone)]
     pub struct PlusPTypeFollower: u8 {
         const HAS_CUSTOM_FORMAT = 0b1;
         const HAS_CUSTOM_CLOCK = 0b10;

--- a/h263/src/types.rs
+++ b/h263/src/types.rs
@@ -191,6 +191,7 @@ bitflags! {
     /// using them together will result in errors in compliant decoders. Some
     /// `PictureTypeCode`s will also prohibit the use of certain
     /// `PictureOption`s.
+    #[derive(Copy, Clone, Debug)]
     pub struct PictureOption : u32 {
         const USE_SPLIT_SCREEN = 0b1;
         const USE_DOCUMENT_CAMERA = 0b10;
@@ -393,6 +394,7 @@ bitflags! {
     /// ITU-T Recommendation H.263 (01/2005) 5.1.9 `SSS`
     ///
     /// Indicates slice configuration when slice-structured mode is enabled.
+    #[derive(Debug)]
     pub struct SliceSubmode : u8 {
         /// Slices must be rectantular rather than free-running.
         const RECTANGULAR_SLICES = 0b1;
@@ -423,6 +425,7 @@ bitflags! {
     ///
     /// Indicates what backchannel messages the encoder would like out of it's
     /// decoding partner.
+    #[derive(Debug)]
     pub struct ReferencePictureSelectionMode : u8 {
         const RESERVED = 0b1;
         const REQUEST_NEGATIVE_ACKNOWLEDGEMENT = 0b10;


### PR DESCRIPTION
Supersedes #46. I fixed the build errors by adding derive directives one by one until the compiler stopped complaining.

Updates the requirements on [bitflags](https://github.com/bitflags/bitflags) to permit the latest version.
- [Release notes](https://github.com/bitflags/bitflags/releases)
- [Changelog](https://github.com/bitflags/bitflags/blob/main/CHANGELOG.md)
- [Commits](https://github.com/bitflags/bitflags/compare/1.3.2...2.0.0)