### PR TITLE
chore: Bump `itertools`, fix some Clippy lints

### DIFF
--- a/deblock/Cargo.toml
+++ b/deblock/Cargo.toml
@@ -7,4 +7,4 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 wide = "0.7.11"
-itertools = "0.11.0"
+itertools = "0.12.1"

--- a/h263/src/decoder.rs
+++ b/h263/src/decoder.rs
@@ -5,6 +5,5 @@ mod picture;
 mod state;
 mod types;
 
-pub use picture::DecodedPicture;
 pub use state::H263State;
 pub use types::DecoderOption;

--- a/h263/src/traits.rs
+++ b/h263/src/traits.rs
@@ -1,7 +1,6 @@
 //! Traits
 
 use num_traits::{CheckedShl, CheckedShr, One, Zero};
-use std::cmp::Eq;
 use std::ops::{BitAnd, BitOr, Not};
 
 pub trait BitReadable:


### PR DESCRIPTION
The former is to remove a (probably insignificant) dependency duplication in Ruffle; the latter two are just random cleanups.