### PR TITLE
ci: Bump `actions/checkout` to `v4`, which uses Node.js 20

### DIFF
--- a/.github/workflows/test_rust.yml
+++ b/.github/workflows/test_rust.yml
@@ -18,7 +18,7 @@ jobs:
         os: [ubuntu-latest, windows-latest, macOS-latest]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
Just to calm the `Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3.` warning annotation.