### PR TITLE
chore: Resolve a nightly `clippy::precedence` lint

### DIFF
--- a/h263/src/parser/reader.rs
+++ b/h263/src/parser/reader.rs
@@ -311,14 +311,13 @@ where
                 0b10 => return Ok(HalfPel::from_unit(-(mantissa + bulk))),
                 0b01 => {
                     mantissa <<= 1;
-                    bulk <<= 1;
                 }
                 0b11 => {
-                    mantissa = mantissa << 1 | 1;
-                    bulk <<= 1;
+                    mantissa = (mantissa << 1) | 1;
                 }
                 _ => return Err(Error::InternalDecoderError),
             }
+            bulk <<= 1;
         }
 
         Err(Error::InvalidMvd)


### PR DESCRIPTION
I'm fairly certain that moving `bulk <<= 1;` out is an improvement to readability.
Merging the match arms and introducing a binding to compute the new value of `mantissa`, however ... bikeshed away! :grin:

See: https://github.com/ruffle-rs/h263-rs/actions/runs/12636214255/job/35207782894?pr=56