### PR TITLE
chore: Resolve `clippy::manual_is_multiple_of` lints

### DIFF
--- a/deblock/src/deblock.rs
+++ b/deblock/src/deblock.rs
@@ -303,7 +303,7 @@ fn deblock_vert(result: &mut [u8], width: usize, strength: u8) {
 #[allow(non_snake_case)]
 #[allow(clippy::identity_op)]
 pub fn deblock(data: &[u8], width: usize, strength: u8) -> Vec<u8> {
-    debug_assert!(data.len() % width == 0);
+    debug_assert!(data.len().is_multiple_of(width));
 
     let mut result = data.to_vec();
 

--- a/h263/src/parser/reader.rs
+++ b/h263/src/parser/reader.rs
@@ -63,7 +63,7 @@ where
         let bits_available = (self.buffer.len() * 8).saturating_sub(self.bits_read);
         let bits_short = (bits_needed as usize).saturating_sub(bits_available);
 
-        (bits_short / 8) + usize::from(bits_short % 8 != 0)
+        bits_short.div_ceil(8)
     }
 
     /// Ensure that at least a certain number of additional bits can be read


### PR DESCRIPTION
Just to unblock CI for other maintenance PRs.

I sure hope this isn't a pessimization: https://doc.rust-lang.org/std/primitive.u32.html#method.div_ceil